### PR TITLE
fix: create logging configuration default false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "allow_default_action" {
 #logs
 variable "create_logging_configuration" {
   type        = bool
-  default     = true
+  default     = false
   description = "Whether to create logging configuration in order start logging from a WAFv2 Web ACL to Amazon Kinesis Data Firehose."
 }
 


### PR DESCRIPTION
## what
In variables.tf: "create_logging_configuration set to false by default"

## why
Terraform will skip creating the logging configuration for the WAFv2 Web ACL. As a result, the Web ACL logs will not be sent to Kinesis Data Firehose.

