### PR TITLE
fix: removed depricated arguments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1260,7 +1260,7 @@ resource "aws_kms_key_policy" "example" {
       },
       {
         "Effect" : "Allow",
-        "Principal" : { "Service" : "logs.${data.aws_region.this.name}.amazonaws.com" },
+        "Principal" : { "Service" : "logs.${data.aws_region.this.region}.amazonaws.com" },
         "Action" : [
           "kms:Encrypt*",
           "kms:Decrypt*",
@@ -1600,10 +1600,10 @@ data "aws_iam_policy_document" "allow_glue_get_table_versions" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/logs",
-      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/${join("", aws_glue_catalog_table.table[*].name)}",
-      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:database/${join("", aws_glue_catalog_database.database[*].name)}",
-      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:catalog",
+      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/logs",
+      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/${join("", aws_glue_catalog_table.table[*].name)}",
+      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:database/${join("", aws_glue_catalog_database.database[*].name)}",
+      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:catalog",
     ]
   }
 }
@@ -1664,7 +1664,7 @@ resource "aws_kinesis_firehose_delivery_stream" "waf" {
         role_arn      = join("", aws_iam_role.firehose[*].arn)
         database_name = join("", aws_glue_catalog_table.table[*].database_name)
         table_name    = join("", aws_glue_catalog_table.table[*].name)
-        region        = data.aws_region.this.name
+        region        = data.aws_region.this.region
       }
     }
   }
@@ -1769,7 +1769,7 @@ data "aws_iam_policy_document" "cloudwatch_logs" {
     resources = ["${join("", aws_cloudwatch_log_group.cloudwatch_logs[*].arn)}:*"]
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:*"]
       variable = "aws:SourceArn"
     }
     condition {


### PR DESCRIPTION
## what  

- Replaced deprecated argument `aws_region.this.name` with `aws_region.this.region` across relevant configurations .
## why  
- The `name` attribute in `aws_region.this` is deprecated. The `region` attribute should be used instead to comply with the latest provider schema and avoid future compatibility issues.

## resource
- [Reference doc](https://registry.terraform.io/providers/hashicorp/aws/6.0.0-beta3/docs/data-sources/region)