### PR TITLE
fix: use data.aws_region.this.name instead of .region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1276,7 +1276,7 @@ resource "aws_kms_key_policy" "example" {
       },
       {
         "Effect" : "Allow",
-        "Principal" : { "Service" : "logs.${data.aws_region.this.region}.amazonaws.com" },
+        "Principal" : { "Service" : "logs.${data.aws_region.this.name}.amazonaws.com" },
         "Action" : [
           "kms:Encrypt*",
           "kms:Decrypt*",
@@ -1620,10 +1620,10 @@ data "aws_iam_policy_document" "allow_glue_get_table_versions" {
     effect = "Allow"
 
     resources = [
-      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/logs",
-      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/${join("", aws_glue_catalog_table.table[*].name)}",
-      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:database/${join("", aws_glue_catalog_database.database[*].name)}",
-      "arn:aws:glue:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:catalog",
+      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/logs",
+      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:table/${join("", aws_glue_catalog_database.database[*].name)}/${join("", aws_glue_catalog_table.table[*].name)}",
+      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:database/${join("", aws_glue_catalog_database.database[*].name)}",
+      "arn:aws:glue:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:catalog",
     ]
   }
 }
@@ -1684,7 +1684,7 @@ resource "aws_kinesis_firehose_delivery_stream" "waf" {
         role_arn      = join("", aws_iam_role.firehose[*].arn)
         database_name = join("", aws_glue_catalog_table.table[*].database_name)
         table_name    = join("", aws_glue_catalog_table.table[*].name)
-        region        = data.aws_region.this.region
+        region        = data.aws_region.this.name
       }
     }
   }
@@ -1789,7 +1789,7 @@ data "aws_iam_policy_document" "cloudwatch_logs" {
     resources = ["${join("", aws_cloudwatch_log_group.cloudwatch_logs[*].arn)}:*"]
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.this.region}:${data.aws_caller_identity.this.account_id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:*"]
       variable = "aws:SourceArn"
     }
     condition {


### PR DESCRIPTION
## Summary
- Replaces 7 occurrences of `data.aws_region.this.region` with `data.aws_region.this.name` in `main.tf`
- The `aws_region` data source exposes a `name` attribute, not `region`; `.region` causes `terraform validate` to fail

Fixes #113

## Affected lines
- `aws_kms_key_policy` (line 1279)
- `aws_iam_policy_document.allow_glue_get_table_versions` (lines 1623–1626)
- `aws_kinesis_firehose_delivery_stream` (line 1687)
- `aws_iam_policy_document.cloudwatch_logs` (line 1792)

## Reference
[AWS provider docs — aws_region data source](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)

## Test plan
- [ ] `terraform validate` passes on the example using `clouddrove/waf/aws` with `waf_enabled = true`, `waf_scop = "REGIONAL"`
- [ ] CI green