### PR TITLE
fix: add web_acl_arn output for WAFv2 Web ACL ARN

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -19,3 +19,8 @@ output "ip_set_arn" {
   value       = join("", aws_wafv2_ip_set.main[*].arn)
   description = "The ARN of Ip_set"
 }
+
+output "web_acl_arn" {
+  value       = join("", aws_wafv2_web_acl.main[*].arn)
+  description = "The ARN of the WAFv2 Web ACL. Use this to associate the ACL with an ALB, CloudFront, or API Gateway."
+}


### PR DESCRIPTION
## Problem

The existing `arn` output returns the **IP set ARN**, which is empty when no IP allowlist (`ip_set_reference_statement`) is configured. The WAFv2 Web ACL ARN is not exported at all.

This forces consumers to patch `.terraform/modules/waf.waf/outputs.tf` after every `terraform init` to get the Web ACL ARN needed for ALB/CloudFront/API Gateway associations.

Reported in #115.

## Fix

Adds a `web_acl_arn` output that returns `aws_wafv2_web_acl.main[*].arn`.

```hcl
output "web_acl_arn" {
  value       = join("", aws_wafv2_web_acl.main[*].arn)
  description = "The ARN of the WAFv2 Web ACL. Use this to associate the ACL with an ALB, CloudFront, or API Gateway."
}
```

## Impact

- Non-breaking: adds a new output, no existing outputs changed
- Enables `aws_wafv2_web_acl_association` in consumer modules without post-init patching

🤖 Generated with [Claude Code](https://claude.com/claude-code)